### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,6 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'ffi'
-  gem 'rails-controller-testing'
-  gem 'rspec-rails', '>= 3.9.0'
 end
 
 group :development do
@@ -72,6 +69,15 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
+  gem 'ffi'
+  gem 'rails-controller-testing'
   gem 'selenium-webdriver'
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 5.0'
 end
+
+group :development, :test do
+  gem 'database_cleaner'
+  gem 'rspec-rails'
+end
+
+gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.37.1)
       addressable
       matrix
@@ -85,6 +88,12 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -238,6 +247,7 @@ GEM
     tzinfo-data (1.2022.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.2.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -260,7 +270,9 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
+  database_cleaner
   debug
   ffi
   importmap-rails
@@ -269,7 +281,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
   rails-controller-testing
-  rspec-rails (>= 3.9.0)
+  rspec-rails
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails
@@ -277,7 +289,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
+  webdrivers (~> 5.0)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ ruby rails_blog.rb
 
 ### Testing
 
-Type these commands into the terminal:
+Run the Rails Server
+
+When server is running, type these command into the terminal:
 
 ```
-rspec
+rspec spec
 ```
 
 ## Authors

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,13 @@
 class PostsController < ApplicationController
   def index
-    @user = User.where(id: params[:user_id]).first
-    @posts = Post.where(author_id: params[:user_id])
+    @user = User.find(params[:user_id])
+    @posts = Post.all
   end
 
   def show
-    @post = Post.find_by(author_id: params[:user_id], id: params[:id])
-    @user = User.where(id: params[:user_id]).first
+    @post = Post.find(params[:id])
+    @comments = @post.comments.includes([:author])
+    @user = @post.author
   end
 
   def new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,15 +5,14 @@
   
 <% @posts.each do |post| %>
    <%= render 'shared/post', post: post%>
- 
       <div>
-        <% @comments = post.recent_comments%>
-        <% @comments.each do |comment|%>
-          <% comenter = User.find_by(id: comment.author_id) %>
-          <%=comenter.name%> : <%=comment.text%>
+        <% post.recent_comments.includes(:author).each do |comment| %>
+        <%=comment.author.name%> : <%=comment.text%>
         <% end %> 
+
  <%= link_to user_post_path(post.author_id, post.id) do %>
   <button type='button'>See full Post</button>
       </div>
     <% end %> 
-<%end%>
+<%end %>
+<button type='button'>Pagination</button>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,8 +1,8 @@
-      <a <%=post.id%>>
+      <div class="post">
         <h2>Post: #<%=post.id%></h2>
         <h3><%= post.title%></h3>
         <p><%= post.text%></p>
         <div>
           <p>comments: <%= post.comments_counter%>, Likes: <%= post.likes_counter%></p>
         </div>
-      </a>
+      </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,16 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,11 +14,12 @@ first_post = Post.create(author_id: first_user.id, title: "Hello", text: "This i
 second_post = Post.create(author_id: first_user.id, title: "Hello", text: "This is my second post", comments_counter: 0, likes_counter: 0)
 third_post = Post.create(author_id: first_user.id, title: "Hello", text: "This is my third post", comments_counter: 0, likes_counter: 0)
 fourth_post = Post.create(author_id: first_user.id, title: "Hello", text: "This is my fourth post", comments_counter: 0, likes_counter: 0)
+fifth_post = Post.create(author_id: second_user.id, title: "Hi there", text: "This is my own post", comments_counter: 0, likes_counter: 0)
 
 Comment.create(post_id: first_post.id, author_id: second_user.id, text: "Hi!")
 Comment.create(post_id: first_post.id, author_id: second_user.id, text: "Hello!")
 Comment.create(post_id: first_post.id, author_id: second_user.id, text: "Hey there!")
-Comment.create(post_id: first_post.id, author_id: second_user.id, text: "Hiii!")
-Comment.create(post_id: first_post.id, author_id: second_user.id, text: "How you doing?")
-Comment.create(post_id: first_post.id, author_id: second_user.id, text: "Aloha")
+Comment.create(post_id: first_post.id, author_id: third_user.id, text: "Hiii!")
+Comment.create(post_id: first_post.id, author_id: third_user.id, text: "How you doing?")
+Comment.create(post_id: first_post.id, author_id: third_user.id, text: "Aloha")
 

--- a/spec/integration/post_integration_spec.rb
+++ b/spec/integration/post_integration_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe 'Index/Show Posts page.', type: :system do
+  subject!(:user) { User.where(name: 'Tony').first }
+  subject!(:post) { Post.where(id: 2).first }
+
+  before(:all) do
+    driven_by(:selenium_chrome_headless)
+    Rails.application.load_seed
+  end
+
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
+  describe 'Visit index page:' do
+    before(:example) do
+      visit("http://localhost:3000/users/#{user.id}/posts")
+    end
+
+    it 'Shows user\'s profile picture' do
+      image = page.all('img')
+      expect(image[0]['src']).to eq('https://cdn.icon-icons.com/icons2/1378/PNG/512/avatardefault_92824.png')
+    end
+
+    it 'Shows user\'s username' do
+      expect(page).to have_content('Tony')
+    end
+
+    it 'Shows user\'s number of written posts.' do
+      expect(page).to have_content('Number of Posts: 4')
+    end
+
+    it 'Shows the post\'s title' do
+      expect(page).to have_content('Hello')
+    end
+
+    it 'Shows part of the posts body' do
+      expect(page).to have_content('This is my first post')
+    end
+
+    it 'Shows the first comments on a post' do
+      expect(page).to have_content('How you doing?')
+    end
+
+    it 'Shows number of comments in post' do
+      expect(page).to have_content('comments: 6')
+    end
+
+    it 'Shows number of likes in a post' do
+      expect(page).to have_content('Likes: 0')
+    end
+
+    it 'Shows pagination button if there are more posts than fit on the view' do
+      expect(page).to have_content('Pagination')
+    end
+
+    it 'Redirects to post\'s show page when See full Post button is clicked' do
+      click_link('See full Post', match: :first)
+      expect(page).to have_current_path "http://localhost:3000/users/#{user.id}/posts/#{post.id}"
+    end
+  end
+
+  describe 'Visit Show page.', type: :system do
+    subject!(:user) { User.where(name: 'Tony').first }
+    subject!(:post) { Post.where(id: 1).first }
+
+    before(:all) do
+      driven_by(:selenium_chrome_headless)
+    end
+
+    before(:example) do
+      visit("http://localhost:3000/users/#{user.id}/posts/#{post.id}")
+    end
+
+    it 'Shows post\'s title' do
+      expect(page).to have_content('This is my first post')
+    end
+
+    it 'Shows who wrote the selected post' do
+      expect(page).to have_content('by Tony')
+    end
+
+    it 'Shows how many comments post has' do
+      expect(page).to have_content('comments: 6')
+    end
+
+    it 'Shows how many likes post has' do
+      expect(page).to have_content('Likes: 0')
+    end
+
+    it 'Shows the post\'s body (text)' do
+      expect(page).to have_content('This is my first post')
+    end
+
+    it 'Shows each commenter\'s username' do
+      expect(page).to have_content('Clint : ')
+      expect(page).to have_content('Peter : ')
+    end
+
+    it 'Shows each commenter\'s comment' do
+      expect(page).to have_content('Hi!')
+      expect(page).to have_content('How you doing?')
+    end
+  end
+end

--- a/spec/integration/post_integration_spec.rb
+++ b/spec/integration/post_integration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Index/Show Posts page.', type: :system do
 
     it 'Shows user\'s profile picture' do
       image = page.all('img')
-      expect(image[0]['src']).to eq('https://cdn.icon-icons.com/icons2/1378/PNG/512/avatardefault_92824.png')
+      expect(image[0]['src']).to eq(user.photo)
     end
 
     it 'Shows user\'s username' do

--- a/spec/integration/user_integration_spec.rb
+++ b/spec/integration/user_integration_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe 'Index/Show Users page.', type: :system do
+  subject!(:user) { User.where(name: 'Tony').first }
+
+  before(:all) do
+    driven_by(:selenium_chrome_headless)
+    Rails.application.load_seed
+  end
+
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
+  describe 'Visit index page:' do
+    before(:example) do
+      visit('http://localhost:3000/')
+    end
+
+    it 'Shows all user\'s usernames' do
+      expect(page).to have_content('Peter')
+      expect(page).to have_content('Tony')
+      expect(page).to have_content('Clint')
+    end
+
+    it 'Shows profile picture of each user' do
+      image = page.all('img')
+      expect(image.size).to eq(3)
+    end
+
+    it 'Shows the number of posts each user has written' do
+      expect(page).to have_content('Number of Posts: 0')
+      expect(page).to have_content('Number of Posts: 4')
+      expect(page).to have_content('Number of Posts: 1')
+    end
+
+    it 'Redirects to User\'s page when clicked' do
+      click_link('Tony')
+      expect(page).to have_current_path user_path(user.id)
+      expect(page).to have_content(user.bio)
+    end
+  end
+
+  describe 'Visit Show page.', type: :system do
+    subject!(:user) { User.where(name: 'Tony').first }
+    subject!(:post) { Post.first }
+
+    before(:all) do
+      driven_by(:selenium_chrome_headless)
+    end
+
+    before(:example) do
+      visit("http://localhost:3000/users/#{user.id}/")
+    end
+
+    it 'Shows user\'s profile picture' do
+      expect(page.all('img').size).to eq(1)
+    end
+
+    it 'Shows user\'s username' do
+      expect(page).to have_content('Tony')
+    end
+
+    it 'Shows number of posts user has written' do
+      expect(page).to have_content('Number of Posts: 4')
+    end
+
+    it 'Shows user\'s bio' do
+      expect(page).to have_content(user.bio)
+    end
+
+    it 'Shows user\'s first 3 posts' do
+      posts = page.all('.post')
+      expect(posts.size).to eq(3)
+    end
+
+    it 'Shows button that leads to user\'s posts' do
+      link = find_link('See all posts', href: "/users/#{user.id}/posts")
+      expect(link).not_to be_nil
+    end
+
+    it 'Redirects to user\'s posts page when See All Posts button is clicked' do
+      click_link('See all posts')
+      expect(page).to have_current_path "http://localhost:3000/users/#{user.id}/posts"
+    end
+
+    it 'Redirects to post\'s show page when See full Post button is clicked' do
+      visit("http://localhost:3000/users/#{user.id}/posts")
+      click_link('See full Post', match: :first)
+      expect(page).to have_content('Your selected Post')
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,35 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  this_user = User.new(name: 'Lou', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 0)
-  this_post = Post.new(author: this_user, title: 'new post', text: 'Lorem Ipsum etc.', comments_counter: 0,
-                       likes_counter: 0)
-  comment = Comment.new(author: this_user, post: this_post, text: 'New Comment Who Dis')
+  subject(:this_user) { User.create(name: 'Lou', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 0) }
+  subject(:this_post) do
+    Post.create(author: this_user, title: 'new post', text: 'Lorem Ipsum etc.', comments_counter: 0,
+                likes_counter: 0)
+  end
+  subject(:comment) { Comment.create(author: this_user, post: this_post, text: 'New Comment Who Dis') }
+
+  after(:all) do
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
+  it 'creates a comment when valid' do
+    expect(comment).to be_valid
+  end
+
+  it 'Saves comment and loads it from database' do
+    expect(comment).to be_an_instance_of(Comment)
+  end
 
   before do
-    this_user.save
-    this_post.save
-    comment.save
+    this_post.comments.create(author: this_user, post: this_post, text: 'New comment #1')
+    this_post.comments.create(author: this_user, post: this_post, text: 'New comment #2')
   end
-
-  context 'Comment Validation' do
-    it 'creates a comment when valid' do
-      expect(comment).to be_valid
-    end
-  end
-
-  context 'Save and Load Comment' do
-    it 'Saves comment and loads it from database' do
-      expect(comment).to be_an_instance_of(Comment)
-    end
-  end
-
-  context 'Update comment counter' do
-    before do
-      Comment.new(author: this_user, post: this_post, text: 'Another Comment')
-    end
-    it 'should add +1 to comment counter' do
-      expect(this_post.comments_counter).to eq(3)
-    end
+  it 'should add +1 to comment counter' do
+    expect(this_post.comments_counter).to eq(2)
   end
 end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Like, type: :model do
   this_post = Post.new(author: this_user, title: 'New post', text: 'Bla bla bla', comments_counter: 0, likes_counter: 1)
   like = Like.new(author: this_user, post: this_post)
 
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
   context 'Like Validation' do
     it 'Creates a like in a post' do
       expect(like).to be_valid

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -85,15 +85,15 @@ RSpec.describe Post, type: :model do
     @this_post.comments_counter = 0
     @this_post.save
     Comment.create(author: @this_user, post: @this_post, text: 'Text1')
-    comment2 = Comment.create(author: @this_user, post: @this_post, text: 'Text2')
-    comment3 = Comment.create(author: @this_user, post: @this_post, text: 'Text3')
-    comment4 = Comment.create(author: @this_user, post: @this_post, text: 'Text4')
-    comment5 = Comment.create(author: @this_user, post: @this_post, text: 'Text5')
-    comment6 = Comment.create(author: @this_user, post: @this_post, text: 'Text6')
-    comment7 = Comment.create(author: @this_user, post: @this_post, text: 'Text7')
-    comment8 = Comment.create(author: @this_user, post: @this_post, text: 'Text8')
-    comment9 = Comment.create(author: @this_user, post: @this_post, text: 'Text9')
-    comment10 = Comment.create(author: @this_user, post: @this_post, text: 'Text10')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text2')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text3')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text4')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text5')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text6')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text7')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text8')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text9')
+    Comment.create(author: @this_user, post: @this_post, text: 'Text10')
     expect(@this_post.recent_comments.length).to eq(5)
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,58 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  this_user = User.new(name: 'Luke', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 1)
-  this_user.save
+  before do
+    @this_user = User.new(name: 'Luke', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 1)
+    @this_post = Post.new(author: @this_user, title: 'Appropiate Title', text: 'Lorem Ipsum etc', comments_counter: 1,
+                          likes_counter: 1)
+    @this_post.save
+  end
 
-  this_post = Post.new(author: this_user, title: 'Appropiate Title', text: 'Lorem Ipsum etc', comments_counter: 1,
-                       likes_counter: 1)
-  this_post.save
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
 
-  describe 'Post Validation' do
-    context 'Successful Case'
-    it 'Validation is Succesful new Post created' do
-      expect(this_post).to be_valid
+  it 'Validation is Succesful new Post created' do
+    @this_post.likes_counter = 0
+    @this_post.comments_counter = 0
+    expect(@this_post).to be_valid
+  end
+
+  it 'Post Validation Fails for Title over 250 chars' do
+    @this_post.likes_counter = 0
+    @this_post.comments_counter = 0
+    @this_post.title = 'o' * 255
+    expect(@this_post).not_to be_valid
+  end
+
+  context 'Fails' do
+    before { @this_post.title = nil }
+    it 'if no title' do
+      expect(@this_post).not_to be_valid
     end
   end
 
-  describe 'Post Validation Fails for Title' do
-    context 'Fails' do
-      before { this_post.title = 'o' * 255 }
-      it 'if title over 250 chars' do
-        expect(this_post).not_to be_valid
-      end
-    end
-
-    context 'Fails' do
-      before { this_post.title = nil }
-      it 'if no title' do
-        expect(this_post).not_to be_valid
-      end
-    end
-
-    context 'Fails' do
-      before { this_post.title = '' }
-      it 'if blank title on post' do
-        expect(this_post).not_to be_valid
-      end
+  context 'Fails' do
+    before { @this_post.title = '' }
+    it 'if blank title on post' do
+      expect(@this_post).not_to be_valid
     end
   end
 
   describe 'Post Validation Fails for Comment Counter' do
     context 'Fails' do
       before do
-        this_post.title = 'Appropiate Title'
-        this_post.comments_counter = -5
+        @this_post.title = 'Appropiate Title'
+        @this_post.comments_counter = -5
       end
       it 'if negative comment count' do
-        expect(this_post).not_to be_valid
+        expect(@this_post).not_to be_valid
       end
     end
 
     context 'Fails' do
-      before { this_post.comments_counter = 'eight' }
+      before { @this_post.comments_counter = 'eight' }
       it 'if string comment count' do
-        expect(this_post).not_to be_valid
+        expect(@this_post).not_to be_valid
       end
     end
   end
@@ -60,38 +64,46 @@ RSpec.describe Post, type: :model do
   describe 'Post Validation Fails for Likes Counter' do
     context 'Fails' do
       before do
-        this_post.comments_counter = 1
-        this_post.likes_counter = -5
+        @this_post.comments_counter = 1
+        @this_post.likes_counter = -5
       end
       it 'if negative like count' do
-        expect(this_post).not_to be_valid
+        expect(@this_post).not_to be_valid
       end
     end
 
     context 'Fails' do
-      before { this_post.likes_counter = 'eight' }
+      before { @this_post.likes_counter = 'eight' }
       it 'if string like count' do
-        expect(this_post).not_to be_valid
+        expect(@this_post).not_to be_valid
       end
     end
   end
 
-  describe 'Method Functionality' do
-    context 'Recent comment method works properly' do
-      it 'returns a valid type' do
-        expect(this_post.recent_comments.length).to eq(0)
-        Comment.create(author: this_user, post: this_post, text: 'FIRST!')
-        expect(this_post.recent_comments.length).to eq(1)
-      end
-    end
+  it 'Method Functionality for Recent posts' do
+    @this_post.likes_counter = 0
+    @this_post.comments_counter = 0
+    @this_post.save
+    Comment.create(author: @this_user, post: @this_post, text: 'Text1')
+    comment2 = Comment.create(author: @this_user, post: @this_post, text: 'Text2')
+    comment3 = Comment.create(author: @this_user, post: @this_post, text: 'Text3')
+    comment4 = Comment.create(author: @this_user, post: @this_post, text: 'Text4')
+    comment5 = Comment.create(author: @this_user, post: @this_post, text: 'Text5')
+    comment6 = Comment.create(author: @this_user, post: @this_post, text: 'Text6')
+    comment7 = Comment.create(author: @this_user, post: @this_post, text: 'Text7')
+    comment8 = Comment.create(author: @this_user, post: @this_post, text: 'Text8')
+    comment9 = Comment.create(author: @this_user, post: @this_post, text: 'Text9')
+    comment10 = Comment.create(author: @this_user, post: @this_post, text: 'Text10')
+    expect(@this_post.recent_comments.length).to eq(5)
+  end
 
-    context 'Update posts counter' do
-      before do
-        Post.new(author: this_user, title: 'new post', text: 'Lorem Ipsum etc', comments_counter: 0, likes_counter: 0)
-      end
-      it 'should add +1 to posts counter' do
-        expect(this_user.post_counter).to eq(2)
-      end
+  context 'Update posts counter' do
+    before do
+      Post.new(author: @this_user, title: 'new post', text: 'Lorem Ipsum etc', comments_counter: 0,
+               likes_counter: 0)
+    end
+    it 'should add +1 to posts counter' do
+      expect(@this_user.post_counter).to eq(2)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe User, type: :model do
     @this_user.post_counter = 0
     @this_user.save
     Post.create(author: @this_user, title: 'Title1', text: 'Text1', comments_counter: 0, likes_counter: 0)
-    post2 = Post.create(author: @this_user, title: 'Title2', text: 'Text2', comments_counter: 0, likes_counter: 0)
-    post3 = Post.create(author: @this_user, title: 'Title3', text: 'Text3', comments_counter: 0, likes_counter: 0)
-    post4 = Post.create(author: @this_user, title: 'Title4', text: 'Text4', comments_counter: 0, likes_counter: 0)
+    Post.create(author: @this_user, title: 'Title2', text: 'Text2', comments_counter: 0, likes_counter: 0)
+    Post.create(author: @this_user, title: 'Title3', text: 'Text3', comments_counter: 0, likes_counter: 0)
+    Post.create(author: @this_user, title: 'Title4', text: 'Text4', comments_counter: 0, likes_counter: 0)
     expect(@this_user.post_counter).to eq(4)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,44 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  user_valid = User.new(name: 'Luke', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 4)
-  user_invalid_name = User.new(name: nil, photo: 'photo_URL', bio: 'Test Dummy', post_counter: 1)
-  user_invalid_post = User.new(name: 'Han', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 'four')
-  user_invalid_post_counter = User.new(name: 'Rei', photo: 'photo_URL', bio: 'Test Dummy', post_counter: -1)
+  before do
+    @this_user = User.new(name: 'Luke', photo: 'photo_URL', bio: 'Test Dummy', post_counter: 4)
+    @this_user.save
+  end
+
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
 
   context 'User Validation' do
     it 'Confirms Valid user' do
-      expect(user_valid).to be_valid
+      expect(@this_user).to be_valid
     end
     it 'Deny user with no name' do
-      expect(user_invalid_name).not_to be_valid
+      @this_user.name = ''
+      expect(@this_user).not_to be_valid
     end
     it 'Deny user with post count as string' do
-      expect(user_invalid_post).not_to be_valid
+      @this_user.post_counter = 'eight'
+      expect(@this_user).not_to be_valid
     end
     it 'Deny user with negative post count' do
-      expect(user_invalid_post_counter).not_to be_valid
+      @this_user.post_counter = -1
+      expect(@this_user).not_to be_valid
     end
   end
 
   context 'Save and Load Validated User' do
     it 'Save user and Loads from Database' do
-      user_valid.save
-      expect(User.find(user_valid.id)).to be_an_instance_of(User)
+      @this_user.save
+      expect(User.find(@this_user.id)).to be_an_instance_of(User)
     end
   end
 
   context 'Invalid user cant be Saved so cant be Loaded' do
     it 'Invalid user not saved to database' do
-      expect(user_invalid_name.save).to eq false
+      @this_user.post_counter = 'eight'
+      expect(@this_user.save).to eq false
     end
   end
 
-  context 'Loads recent posts from Valid User' do
-    user = User.first
-    it 'Returns the expected data type' do
-      recent = user.recent_posts
-      expect(recent.length).to be_a_kind_of(Integer)
-    end
+  it 'Loads recent posts from Valid User' do
+    @this_user.post_counter = 0
+    @this_user.save
+    Post.create(author: @this_user, title: 'Title1', text: 'Text1', comments_counter: 0, likes_counter: 0)
+    post2 = Post.create(author: @this_user, title: 'Title2', text: 'Text2', comments_counter: 0, likes_counter: 0)
+    post3 = Post.create(author: @this_user, title: 'Title3', text: 'Text3', comments_counter: 0, likes_counter: 0)
+    post4 = Post.create(author: @this_user, title: 'Title4', text: 'Text4', comments_counter: 0, likes_counter: 0)
+    expect(@this_user.post_counter).to eq(4)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,9 @@ require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rspec'
+require 'webdrivers'
+require 'selenium-webdriver'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -37,7 +40,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
@@ -61,4 +64,27 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+  # This block must be here, do not combine with the other `before(:each)` block.
+  # This makes it so Capybara can see the database.
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end
+Capybara.configure do |config|
+  config.run_server = false
+end
+session = Capybara::Session.new(:selenium)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,4 +87,3 @@ end
 Capybara.configure do |config|
   config.run_server = false
 end
-session = Capybara::Session.new(:selenium)

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -1,17 +1,30 @@
 require 'rails_helper'
 
-RSpec.describe 'Users', type: :request do
+RSpec.describe 'Posts Path', type: :request do
+  before(:all) do
+    @this_user = User.create(name: 'Malcolm', photo: 'Photo_URL', bio: 'Im in the Middle', post_counter: 0)
+    @this_post = Post.create(author: @this_user, title: 'Test Post', text: 'This is a test post', likes_counter: 0,
+                             comments_counter: 0)
+  end
+
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
   describe 'Get page post #index' do
     before(:each) do
-      get '/users/3/posts'
+      get "/users/#{@this_user.id}/posts"
     end
 
     it 'shows user\'s posts successfully' do
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it 'renders template correctly' do
-      expect(response).to render_template('index')
+      expect(response).to render_template('posts/index')
     end
 
     it 'renders and placeholder matches content' do
@@ -21,11 +34,11 @@ RSpec.describe 'Users', type: :request do
 
   describe 'GET user page #show' do
     before(:each) do
-      get '/users/3/posts/6'
+      get "/users/#{@this_user.id}/posts/#{@this_post.id}"
     end
 
     it 'shows selected post successfully' do
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it 'renders template correctly' do

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
-RSpec.describe 'Users', type: :request do
+RSpec.describe 'Users Path', type: :request do
+  before(:all) do
+    @this_user = User.create(name: 'Malcolm', photo: 'Photo_URL', bio: 'Im in the Middle', post_counter: 0)
+    @this_post = Post.create(author: @this_user, title: 'Test Post', text: 'This is a test post', likes_counter: 0,
+                             comments_counter: 0)
+  end
+
+  after(:all) do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+  end
+
   describe 'GET users page #index' do
     before(:each) do
       get '/users'
@@ -21,7 +34,7 @@ RSpec.describe 'Users', type: :request do
 
   describe 'GET user page #show' do
     before(:each) do
-      get '/users/3'
+      get "/users/#{@this_user.id}"
     end
 
     it 'shows selected user successfully' do


### PR DESCRIPTION
On this PR we:

- Corrected the N+1 problem
- Created Integration specs for:
  - User index page:
    - to see the username of all other users.
    - to see the profile picture for each user.
    - to see the number of posts each user has written.
    - to redirect to that user's show page.
  
  - user show page:

    - to see the user's profile picture.
    - to see the user's username.
    - to see the number of posts the user has written.
    - to see the user's bio.
    - to see the user's first 3 posts.
    - to see a button that lets me view all of a user's posts.
    - to redirect to a post's show page.
    - to redirect to a user's post's index page.

  - User post index page:

    - to see the user's profile picture.
    - to see the user's username.
    - to see the number of posts the user has written.
    - to see a post's title.
    - to see some of the post's body.
    - to see the first comments on a post.
    - to see how many comments a post has.
    - to see how many likes a post has.
    - to see a section for pagination if there are more posts than fit on the view.
    - to redirect to a post's show page.

  - Post show page:

    - to see the post's title.
    - to see who wrote the post.
    - to see how many comments it has.
    - to see how many likes it has.
    - to see the post body.
    - to see the username of each commentor.
    - to see the comment each commentor left.
 